### PR TITLE
Add routed homepage pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "react-router-dom": "^7.14.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-router-dom:
+        specifier: ^7.14.2
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -640,6 +643,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1084,6 +1091,23 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-router-dom@7.14.2:
+    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -1116,6 +1140,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1933,6 +1960,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2327,6 +2356,20 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.5
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
   react@19.2.5: {}
 
   redent@3.0.0:
@@ -2366,6 +2409,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,10 +1,36 @@
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
 import App from './App'
 
-describe('App', () => {
-  it('renders the page heading', () => {
-    render(<App />)
-    expect(screen.getByRole('heading', { level: 1, name: 'demo-homepage' })).toBeInTheDocument()
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>,
+  )
+}
+
+describe('App routing', () => {
+  it('renders the Home page at /', () => {
+    renderAt('/')
+    expect(screen.getByRole('heading', { level: 1, name: 'Home' })).toBeInTheDocument()
+  })
+
+  it('renders the Blog page at /blog', () => {
+    renderAt('/blog')
+    expect(screen.getByRole('heading', { level: 1, name: 'Blog' })).toBeInTheDocument()
+  })
+
+  it('renders the BlogPost page at /blog/:slug', () => {
+    renderAt('/blog/hello-world')
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Blog Post: hello-world' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the Gallery page at /gallery', () => {
+    renderAt('/gallery')
+    expect(screen.getByRole('heading', { level: 1, name: 'Gallery' })).toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,28 @@
+import { Link, Route, Routes } from 'react-router-dom'
+import Home from './pages/Home'
+import Blog from './pages/Blog'
+import BlogPost from './pages/BlogPost'
+import Gallery from './pages/Gallery'
+
 function App() {
   return (
-    <main>
-      <h1>demo-homepage</h1>
-    </main>
+    <>
+      <nav>
+        <Link to="/">Home</Link>
+        {' | '}
+        <Link to="/blog">Blog</Link>
+        {' | '}
+        <Link to="/gallery">Gallery</Link>
+      </nav>
+      <main>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/blog" element={<Blog />} />
+          <Route path="/blog/:slug" element={<BlogPost />} />
+          <Route path="/gallery" element={<Gallery />} />
+        </Routes>
+      </main>
+    </>
   )
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,0 +1,5 @@
+function Blog() {
+  return <h1>Blog</h1>
+}
+
+export default Blog

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,0 +1,8 @@
+import { useParams } from 'react-router-dom'
+
+function BlogPost() {
+  const { slug } = useParams<{ slug: string }>()
+  return <h1>Blog Post: {slug}</h1>
+}
+
+export default BlogPost

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,0 +1,5 @@
+function Gallery() {
+  return <h1>Gallery</h1>
+}
+
+export default Gallery

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,5 @@
+function Home() {
+  return <h1>Home</h1>
+}
+
+export default Home


### PR DESCRIPTION
## Summary
- Add React Router setup with browser routing and navigation links.
- Add Home, Blog, BlogPost, and Gallery route components.
- Update app routing tests to cover the new pages and dynamic blog slug route.

## Checks
- pnpm test:run
- pnpm build
- pnpm lint