### PR TITLE
Add shared Layout with header/footer and active nav (closes #3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { Link, Route, Routes } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
+import Layout from './components/Layout'
 import Home from './pages/Home'
 import Blog from './pages/Blog'
 import BlogPost from './pages/BlogPost'
@@ -6,23 +7,14 @@ import Gallery from './pages/Gallery'
 
 function App() {
   return (
-    <>
-      <nav>
-        <Link to="/">Home</Link>
-        {' | '}
-        <Link to="/blog">Blog</Link>
-        {' | '}
-        <Link to="/gallery">Gallery</Link>
-      </nav>
-      <main>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/blog" element={<Blog />} />
-          <Route path="/blog/:slug" element={<BlogPost />} />
-          <Route path="/gallery" element={<Gallery />} />
-        </Routes>
-      </main>
-    </>
+    <Routes>
+      <Route element={<Layout />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/blog" element={<Blog />} />
+        <Route path="/blog/:slug" element={<BlogPost />} />
+        <Route path="/gallery" element={<Gallery />} />
+      </Route>
+    </Routes>
   )
 }
 

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -1,0 +1,87 @@
+.layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.site-header {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  background: var(--header-bg, #ffffff);
+}
+
+.site-header__inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.site-logo {
+  font-weight: 700;
+  font-size: 1.125rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.site-nav {
+  list-style: none;
+  display: flex;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+.site-nav__link {
+  text-decoration: none;
+  color: inherit;
+  padding: 0.25rem 0;
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav__link--active {
+  border-bottom-color: currentColor;
+  font-weight: 600;
+}
+
+.site-main {
+  flex: 1;
+  max-width: 1080px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  box-sizing: border-box;
+}
+
+.site-footer {
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  background: var(--footer-bg, #f6f6f6);
+}
+
+.site-footer__inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.site-footer p {
+  margin: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .site-header {
+    background: #1a1a1a;
+    border-bottom-color: rgba(255, 255, 255, 0.1);
+  }
+  .site-footer {
+    background: #141414;
+    border-top-color: rgba(255, 255, 255, 0.1);
+  }
+}

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import App from '../App'
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>,
+  )
+}
+
+describe('Layout', () => {
+  it('renders header navigation and footer on every page', () => {
+    renderAt('/')
+    const nav = screen.getByRole('navigation', { name: 'Primary' })
+    expect(within(nav).getByRole('link', { name: 'Home' })).toBeInTheDocument()
+    expect(within(nav).getByRole('link', { name: 'Blog' })).toBeInTheDocument()
+    expect(within(nav).getByRole('link', { name: 'Gallery' })).toBeInTheDocument()
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument()
+  })
+
+  it('highlights the active nav link for the current route', () => {
+    renderAt('/blog')
+    const nav = screen.getByRole('navigation', { name: 'Primary' })
+    expect(within(nav).getByRole('link', { name: 'Blog' })).toHaveClass(
+      'site-nav__link--active',
+    )
+    expect(within(nav).getByRole('link', { name: 'Home' })).not.toHaveClass(
+      'site-nav__link--active',
+    )
+  })
+
+  it('navigates between pages via nav links', async () => {
+    const user = userEvent.setup()
+    renderAt('/')
+    await user.click(screen.getByRole('link', { name: 'Gallery' }))
+    expect(screen.getByRole('heading', { level: 1, name: 'Gallery' })).toBeInTheDocument()
+  })
+})

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,49 @@
+import { NavLink, Outlet } from 'react-router-dom'
+import './Layout.css'
+
+const navItems = [
+  { to: '/', label: 'Home', end: true },
+  { to: '/blog', label: 'Blog', end: false },
+  { to: '/gallery', label: 'Gallery', end: false },
+]
+
+function Layout() {
+  return (
+    <div className="layout">
+      <header className="site-header">
+        <div className="site-header__inner">
+          <NavLink to="/" className="site-logo" end>
+            Demo Homepage
+          </NavLink>
+          <nav aria-label="Primary">
+            <ul className="site-nav">
+              {navItems.map((item) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    end={item.end}
+                    className={({ isActive }) =>
+                      isActive ? 'site-nav__link site-nav__link--active' : 'site-nav__link'
+                    }
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </header>
+      <main className="site-main">
+        <Outlet />
+      </main>
+      <footer className="site-footer">
+        <div className="site-footer__inner">
+          <p>&copy; {new Date().getFullYear()} Demo Homepage. All rights reserved.</p>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+export default Layout


### PR DESCRIPTION
## Summary
- Introduce `<Layout>` component (header with site logo + NavLink-based primary nav, footer with copyright) and wrap all routes via a nested `<Outlet />` in `App.tsx`.
- Active page is highlighted in the nav via `NavLink`'s active class; styles include light/dark support.
- Tests cover header/nav/footer rendering, active-link highlighting, and route navigation between pages.

## Test plan
- [x] `pnpm test:run` (7/7 pass)
- [x] `pnpm lint`
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)