### PR TITLE
Add persona data with Hero and About sections (closes #4)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
 import App from './App'
+import { persona } from './data/persona'
 
 function renderAt(path: string) {
   return render(
@@ -12,9 +13,11 @@ function renderAt(path: string) {
 }
 
 describe('App routing', () => {
-  it('renders the Home page at /', () => {
+  it('renders the Home page Hero and About at /', () => {
     renderAt('/')
-    expect(screen.getByRole('heading', { level: 1, name: 'Home' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: persona.tagline })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'About' })).toBeInTheDocument()
+    expect(screen.getByText(persona.bio)).toBeInTheDocument()
   })
 
   it('renders the Blog page at /blog', () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,6 +18,10 @@ describe('App routing', () => {
     expect(screen.getByRole('heading', { level: 1, name: persona.tagline })).toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 2, name: 'About' })).toBeInTheDocument()
     expect(screen.getByText(persona.bio)).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: persona.heroImageAlt })).toHaveAttribute(
+      'src',
+      persona.heroImageUrl,
+    )
   })
 
   it('renders the Blog page at /blog', () => {

--- a/src/components/About.css
+++ b/src/components/About.css
@@ -1,0 +1,76 @@
+.about {
+  padding: 4rem 1.5rem;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.about__inner {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.about__heading {
+  margin: 0 0 2rem;
+  font-size: 1.75rem;
+  letter-spacing: 0.04em;
+  border-bottom: 2px solid #2563eb;
+  padding-bottom: 0.5rem;
+  display: inline-block;
+}
+
+.about__body {
+  display: flex;
+  gap: 2.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.about__avatar {
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.12);
+  flex-shrink: 0;
+}
+
+.about__text {
+  flex: 1 1 320px;
+}
+
+.about__name {
+  margin: 0 0 0.75rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.about__bio {
+  margin: 0 0 1.5rem;
+  line-height: 1.85;
+  color: #334155;
+}
+
+.about__facts {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem 1.5rem;
+}
+
+.about__fact {
+  margin: 0;
+}
+
+.about__fact dt {
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #64748b;
+  margin-bottom: 0.25rem;
+}
+
+.about__fact dd {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,47 @@
+import { persona } from '../data/persona'
+import './About.css'
+
+function About() {
+  return (
+    <section className="about" aria-labelledby="about-heading">
+      <div className="about__inner">
+        <h2 id="about-heading" className="about__heading">
+          About
+        </h2>
+        <div className="about__body">
+          <img
+            className="about__avatar"
+            src={persona.avatarUrl}
+            alt={`${persona.name} のプロフィール画像`}
+            width={160}
+            height={160}
+          />
+          <div className="about__text">
+            <p className="about__name">{persona.name}</p>
+            <p className="about__bio">{persona.bio}</p>
+            <dl className="about__facts">
+              <div className="about__fact">
+                <dt>訪問国数</dt>
+                <dd>{persona.countriesVisited} カ国</dd>
+              </div>
+              <div className="about__fact">
+                <dt>拠点</dt>
+                <dd>{persona.basedIn}</dd>
+              </div>
+              <div className="about__fact">
+                <dt>旅歴</dt>
+                <dd>{persona.yearsTraveling} 年</dd>
+              </div>
+              <div className="about__fact">
+                <dt>好きな地域</dt>
+                <dd>{persona.favoriteRegion}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default About

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -3,12 +3,27 @@
     radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 60%),
     linear-gradient(135deg, #1e3a8a 0%, #2563eb 55%, #0ea5e9 100%);
   color: #fff;
-  padding: 5rem 1.5rem 4.5rem;
+  padding: 4.5rem 1.5rem;
 }
 
 .hero__inner {
-  max-width: 960px;
+  max-width: 1120px;
   margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: 3rem;
+  align-items: center;
+}
+
+@media (max-width: 820px) {
+  .hero__inner {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+}
+
+.hero__copy {
+  min-width: 0;
 }
 
 .hero__greeting {
@@ -32,4 +47,22 @@
   line-height: 1.7;
   max-width: 36rem;
   opacity: 0.92;
+}
+
+.hero__visual {
+  position: relative;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  box-shadow:
+    0 25px 60px rgba(8, 19, 56, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.08) inset;
+  aspect-ratio: 16 / 10;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.hero__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -1,0 +1,35 @@
+.hero {
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 60%),
+    linear-gradient(135deg, #1e3a8a 0%, #2563eb 55%, #0ea5e9 100%);
+  color: #fff;
+  padding: 5rem 1.5rem 4.5rem;
+}
+
+.hero__inner {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.hero__greeting {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.hero__title {
+  margin: 0 0 1.25rem;
+  font-size: clamp(1.9rem, 4.5vw, 3rem);
+  line-height: 1.25;
+  font-weight: 700;
+}
+
+.hero__subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  max-width: 36rem;
+  opacity: 0.92;
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,14 +5,26 @@ function Hero() {
   return (
     <section className="hero" aria-labelledby="hero-heading">
       <div className="hero__inner">
-        <p className="hero__greeting">Hello, traveler —</p>
-        <h1 id="hero-heading" className="hero__title">
-          {persona.tagline}
-        </h1>
-        <p className="hero__subtitle">
-          {persona.name} の旅ブログへようこそ。{persona.countriesVisited} カ国を巡って出会った、
-          小さな景色と物語を集めています。
-        </p>
+        <div className="hero__copy">
+          <p className="hero__greeting">Hello, traveler —</p>
+          <h1 id="hero-heading" className="hero__title">
+            {persona.tagline}
+          </h1>
+          <p className="hero__subtitle">
+            {persona.name} の旅ブログへようこそ。{persona.countriesVisited} カ国を巡って出会った、
+            小さな景色と物語を集めています。
+          </p>
+        </div>
+        <div className="hero__visual">
+          <img
+            className="hero__image"
+            src={persona.heroImageUrl}
+            alt={persona.heroImageAlt}
+            width={1280}
+            height={720}
+            loading="eager"
+          />
+        </div>
       </div>
     </section>
   )

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,21 @@
+import { persona } from '../data/persona'
+import './Hero.css'
+
+function Hero() {
+  return (
+    <section className="hero" aria-labelledby="hero-heading">
+      <div className="hero__inner">
+        <p className="hero__greeting">Hello, traveler —</p>
+        <h1 id="hero-heading" className="hero__title">
+          {persona.tagline}
+        </h1>
+        <p className="hero__subtitle">
+          {persona.name} の旅ブログへようこそ。{persona.countriesVisited} カ国を巡って出会った、
+          小さな景色と物語を集めています。
+        </p>
+      </div>
+    </section>
+  )
+}
+
+export default Hero

--- a/src/data/persona.ts
+++ b/src/data/persona.ts
@@ -1,0 +1,21 @@
+export type Persona = {
+  name: string
+  avatarUrl: string
+  tagline: string
+  bio: string
+  countriesVisited: number
+  basedIn: string
+  yearsTraveling: number
+  favoriteRegion: string
+}
+
+export const persona: Persona = {
+  name: 'Aoi Tachibana',
+  avatarUrl: 'https://placehold.co/240x240/2b6cb0/ffffff?text=Aoi',
+  tagline: '世界の路地裏から、おかえりなさいの一杯を。',
+  bio: 'カメラとノートを片手に、ふらりと知らない街へ降り立つのが好きな旅ブロガーです。観光名所よりも、地元の人が通う食堂や朝市、夕方の路地裏に流れる空気が大好物。「行ってみたい」を「明日の予定」に変えるような、等身大の旅の記録をお届けしています。',
+  countriesVisited: 32,
+  basedIn: '東京 / Tokyo, Japan',
+  yearsTraveling: 8,
+  favoriteRegion: '東南アジアと地中海沿岸',
+}

--- a/src/data/persona.ts
+++ b/src/data/persona.ts
@@ -1,6 +1,8 @@
 export type Persona = {
   name: string
   avatarUrl: string
+  heroImageUrl: string
+  heroImageAlt: string
   tagline: string
   bio: string
   countriesVisited: number
@@ -12,6 +14,8 @@ export type Persona = {
 export const persona: Persona = {
   name: 'Aoi Tachibana',
   avatarUrl: 'https://placehold.co/240x240/2b6cb0/ffffff?text=Aoi',
+  heroImageUrl: 'https://picsum.photos/seed/aoi-travel-hero/1280/720',
+  heroImageAlt: '夕暮れの路地に灯がともる、海沿いの街並み',
   tagline: '世界の路地裏から、おかえりなさいの一杯を。',
   bio: 'カメラとノートを片手に、ふらりと知らない街へ降り立つのが好きな旅ブロガーです。観光名所よりも、地元の人が通う食堂や朝市、夕方の路地裏に流れる空気が大好物。「行ってみたい」を「明日の予定」に変えるような、等身大の旅の記録をお届けしています。',
   countriesVisited: 32,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,13 @@
+import About from '../components/About'
+import Hero from '../components/Hero'
+
 function Home() {
-  return <h1>Home</h1>
+  return (
+    <>
+      <Hero />
+      <About />
+    </>
+  )
 }
 
 export default Home


### PR DESCRIPTION
## Summary
- Define fictional travel-blogger persona in `src/data/persona.ts` (name, avatar placeholder, tagline, bio, country count, etc.)
- Add Hero section with key visual gradient + tagline as the page h1
- Add About section showing avatar, bio, and key profile facts
- Wire both into `/` via `Home.tsx`; update routing test to match new headings

Closes #4

## Test plan
- [x] `pnpm test:run` — 7 tests passing
- [x] `pnpm build` — type check + production build clean
- [ ] Visual check of `/` in dev server (Hero + About render, persona is conveyed)