### PR TITLE
Add mock posts data and blog list page (closes #5)

### DIFF
--- a/src/components/BlogCard.css
+++ b/src/components/BlogCard.css
@@ -1,0 +1,77 @@
+.blog-card {
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  overflow: hidden;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.blog-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+}
+
+.blog-card__link {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.blog-card__cover {
+  aspect-ratio: 16 / 9;
+  background: #f1f1f1;
+  overflow: hidden;
+}
+
+.blog-card__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.blog-card__body {
+  padding: 1rem 1.125rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.blog-card__date {
+  font-size: 0.8125rem;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.blog-card__title {
+  font-size: 1.125rem;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.blog-card__excerpt {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: rgba(0, 0, 0, 0.7);
+  line-height: 1.6;
+}
+
+.blog-card__tags {
+  list-style: none;
+  margin: 0.25rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.blog-card__tag {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.7);
+}

--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router-dom'
+import type { Post } from '../data/posts'
+import './BlogCard.css'
+
+const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+})
+
+type Props = {
+  post: Post
+}
+
+function BlogCard({ post }: Props) {
+  return (
+    <article className="blog-card">
+      <Link to={`/blog/${post.slug}`} className="blog-card__link">
+        <div className="blog-card__cover">
+          <img src={post.coverImage} alt="" loading="lazy" />
+        </div>
+        <div className="blog-card__body">
+          <time className="blog-card__date" dateTime={post.date}>
+            {dateFormatter.format(new Date(post.date))}
+          </time>
+          <h2 className="blog-card__title">{post.title}</h2>
+          <p className="blog-card__excerpt">{post.excerpt}</p>
+          <ul className="blog-card__tags" aria-label="Tags">
+            {post.tags.map((tag) => (
+              <li key={tag} className="blog-card__tag">
+                {tag}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Link>
+    </article>
+  )
+}
+
+export default BlogCard

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -1,0 +1,74 @@
+export type Post = {
+  title: string
+  slug: string
+  date: string
+  excerpt: string
+  coverImage: string
+  tags: string[]
+}
+
+export const posts: Post[] = [
+  {
+    title: 'Hello World — このサイトについて',
+    slug: 'hello-world',
+    date: '2026-01-12',
+    excerpt:
+      'デモ用ホームページの最初の記事です。何を作っていて、なぜこのサイトを公開しているのかを簡単に紹介します。',
+    coverImage: 'https://picsum.photos/seed/hello-world/800/450',
+    tags: ['お知らせ', '雑記'],
+  },
+  {
+    title: 'Vite + React + TypeScript で始めるミニマル構成',
+    slug: 'vite-react-typescript-minimal',
+    date: '2026-01-28',
+    excerpt:
+      '最小構成で動かすためにどんな選択をしたか、ESLint や tsconfig の初期値も含めてざっくりまとめました。',
+    coverImage: 'https://picsum.photos/seed/vite-react/800/450',
+    tags: ['React', 'TypeScript', 'Vite'],
+  },
+  {
+    title: 'React Router でレイアウト共有を整理する',
+    slug: 'react-router-shared-layout',
+    date: '2026-02-14',
+    excerpt:
+      'ヘッダー・フッターを各ページで重複させないために、ネストルートと <Outlet /> をどう使ったかの記録です。',
+    coverImage: 'https://picsum.photos/seed/router-layout/800/450',
+    tags: ['React', 'React Router'],
+  },
+  {
+    title: 'デザインの最初の一歩は「余白」から',
+    slug: 'first-step-is-spacing',
+    date: '2026-03-03',
+    excerpt:
+      '色やフォントよりも先に、行間と余白を整えるだけでサイトの印象は驚くほど変わる、という小さな気づき。',
+    coverImage: 'https://picsum.photos/seed/spacing/800/450',
+    tags: ['デザイン', 'UI'],
+  },
+  {
+    title: 'ブログ一覧のカードレイアウトを CSS Grid で組む',
+    slug: 'blog-grid-with-css-grid',
+    date: '2026-03-22',
+    excerpt:
+      'auto-fill と minmax() を使って、画面幅に応じて列数が変わるカードグリッドを作ります。',
+    coverImage: 'https://picsum.photos/seed/css-grid/800/450',
+    tags: ['CSS', 'レイアウト'],
+  },
+  {
+    title: '個人サイトに何を書くか問題',
+    slug: 'what-to-write-on-personal-site',
+    date: '2026-04-09',
+    excerpt:
+      '更新が止まりがちな個人サイトを、続けられる場所にするために自分なりに決めたゆるいルール。',
+    coverImage: 'https://picsum.photos/seed/personal-site/800/450',
+    tags: ['雑記'],
+  },
+  {
+    title: 'ダミー記事と一覧ページのモック実装',
+    slug: 'mock-posts-and-list-page',
+    date: '2026-04-25',
+    excerpt:
+      '本文はまだないけれど、データ構造と一覧の見た目を先に固めるために用意したモックの話。',
+    coverImage: 'https://picsum.photos/seed/mock-posts/800/450',
+    tags: ['React', 'モック'],
+  },
+]

--- a/src/pages/Blog.css
+++ b/src/pages/Blog.css
@@ -1,0 +1,14 @@
+.blog-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.blog-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,5 +1,22 @@
+import BlogCard from '../components/BlogCard'
+import { posts } from '../data/posts'
+import './Blog.css'
+
 function Blog() {
-  return <h1>Blog</h1>
+  const sortedPosts = [...posts].sort((a, b) => b.date.localeCompare(a.date))
+
+  return (
+    <div className="blog-page">
+      <h1>Blog</h1>
+      <ul className="blog-grid">
+        {sortedPosts.map((post) => (
+          <li key={post.slug}>
+            <BlogCard post={post} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }
 
 export default Blog


### PR DESCRIPTION
## Summary
- Add 7 dummy posts in `src/data/posts.ts` with `title / slug / date / excerpt / coverImage / tags`.
- Render a responsive CSS Grid of `BlogCard`s on `/blog`, sorted by date descending; each card links to `/blog/:slug`.

## Test plan
- [x] `pnpm test:run` (7/7 pass)
- [x] `pnpm build` (typecheck + production build succeed)
- [ ] Manual: visit `/blog`, confirm cards render in date-descending order and clicking navigates to `/blog/:slug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)