### PR TITLE
Add gallery lightbox with keyboard navigation (closes #8)

### DIFF
--- a/src/components/Lightbox.css
+++ b/src/components/Lightbox.css
@@ -1,0 +1,82 @@
+.lightbox-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1.5rem;
+}
+
+.lightbox-figure {
+  margin: 0;
+  max-width: min(1200px, 95vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.lightbox-image {
+  max-width: 100%;
+  max-height: 80vh;
+  object-fit: contain;
+  border-radius: 4px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+}
+
+.lightbox-caption {
+  color: #f5f5f5;
+  font-size: 0.95rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.lightbox-counter {
+  color: #aaa;
+  font-size: 0.8rem;
+}
+
+.lightbox-button {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 50%;
+  width: 3rem;
+  height: 3rem;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+
+.lightbox-button:hover,
+.lightbox-button:focus-visible {
+  background: rgba(255, 255, 255, 0.25);
+  outline: none;
+}
+
+.lightbox-close {
+  top: 1rem;
+  right: 1rem;
+}
+
+.lightbox-prev {
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.lightbox-next {
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -1,0 +1,86 @@
+import { useEffect } from 'react'
+import type { Photo } from '../data/photos'
+import './Lightbox.css'
+
+type LightboxProps = {
+  photos: Photo[]
+  index: number
+  onClose: () => void
+  onPrev: () => void
+  onNext: () => void
+}
+
+function Lightbox({ photos, index, onClose, onPrev, onNext }: LightboxProps) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+      else if (e.key === 'ArrowLeft') onPrev()
+      else if (e.key === 'ArrowRight') onNext()
+    }
+    window.addEventListener('keydown', handleKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [onClose, onPrev, onNext])
+
+  const photo = photos[index]
+  if (!photo) return null
+
+  return (
+    <div
+      className="lightbox-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label="拡大表示"
+      onClick={onClose}
+    >
+      <button
+        type="button"
+        className="lightbox-button lightbox-close"
+        aria-label="閉じる"
+        onClick={(e) => {
+          e.stopPropagation()
+          onClose()
+        }}
+      >
+        ×
+      </button>
+      <button
+        type="button"
+        className="lightbox-button lightbox-prev"
+        aria-label="前の写真"
+        onClick={(e) => {
+          e.stopPropagation()
+          onPrev()
+        }}
+      >
+        ‹
+      </button>
+      <figure className="lightbox-figure" onClick={(e) => e.stopPropagation()}>
+        <img src={photo.src} alt={photo.caption} className="lightbox-image" />
+        <figcaption className="lightbox-caption">
+          {photo.caption}
+          <span className="lightbox-counter">
+            {index + 1} / {photos.length}
+          </span>
+        </figcaption>
+      </figure>
+      <button
+        type="button"
+        className="lightbox-button lightbox-next"
+        aria-label="次の写真"
+        onClick={(e) => {
+          e.stopPropagation()
+          onNext()
+        }}
+      >
+        ›
+      </button>
+    </div>
+  )
+}
+
+export default Lightbox

--- a/src/data/photos.ts
+++ b/src/data/photos.ts
@@ -1,0 +1,48 @@
+export type Photo = {
+  src: string
+  thumb: string
+  caption: string
+}
+
+export const photos: Photo[] = [
+  {
+    src: 'https://picsum.photos/seed/photo-morning/1600/1067',
+    thumb: 'https://picsum.photos/seed/photo-morning/600/400',
+    caption: '早朝の散歩道、まだ静かな街並み',
+  },
+  {
+    src: 'https://picsum.photos/seed/photo-cafe/1600/1067',
+    thumb: 'https://picsum.photos/seed/photo-cafe/600/400',
+    caption: '近所のカフェで一杯',
+  },
+  {
+    src: 'https://picsum.photos/seed/photo-mountain/1600/1067',
+    thumb: 'https://picsum.photos/seed/photo-mountain/600/400',
+    caption: '休日に登った山の頂上から',
+  },
+  {
+    src: 'https://picsum.photos/seed/photo-desk/1600/1067',
+    thumb: 'https://picsum.photos/seed/photo-desk/600/400',
+    caption: '作業デスクの今日の様子',
+  },
+  {
+    src: 'https://picsum.photos/seed/photo-night/1600/1067',
+    thumb: 'https://picsum.photos/seed/photo-night/600/400',
+    caption: '夜の街、信号待ちの一枚',
+  },
+  {
+    src: 'https://picsum.photos/seed/photo-flower/1600/1067',
+    thumb: 'https://picsum.photos/seed/photo-flower/600/400',
+    caption: '道端で見つけた小さな花',
+  },
+  {
+    src: 'https://picsum.photos/seed/photo-book/1600/1067',
+    thumb: 'https://picsum.photos/seed/photo-book/600/400',
+    caption: '読みかけの本と窓辺の光',
+  },
+  {
+    src: 'https://picsum.photos/seed/photo-sea/1600/1067',
+    thumb: 'https://picsum.photos/seed/photo-sea/600/400',
+    caption: '久しぶりに会いに行った海',
+  },
+]

--- a/src/pages/Gallery.css
+++ b/src/pages/Gallery.css
@@ -1,0 +1,41 @@
+.gallery-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.gallery-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.gallery-item {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: 6px;
+  overflow: hidden;
+  aspect-ratio: 3 / 2;
+  transition: transform 0.15s;
+}
+
+.gallery-item:hover,
+.gallery-item:focus-visible {
+  transform: scale(1.02);
+  outline: 2px solid #4a90e2;
+  outline-offset: 2px;
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,5 +1,45 @@
+import { useState } from 'react'
+import Lightbox from '../components/Lightbox'
+import { photos } from '../data/photos'
+import './Gallery.css'
+
 function Gallery() {
-  return <h1>Gallery</h1>
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
+
+  const close = () => setOpenIndex(null)
+  const prev = () =>
+    setOpenIndex((i) => (i === null ? null : (i - 1 + photos.length) % photos.length))
+  const next = () =>
+    setOpenIndex((i) => (i === null ? null : (i + 1) % photos.length))
+
+  return (
+    <div className="gallery-page">
+      <h1>Gallery</h1>
+      <ul className="gallery-grid">
+        {photos.map((photo, i) => (
+          <li key={photo.src}>
+            <button
+              type="button"
+              className="gallery-item"
+              onClick={() => setOpenIndex(i)}
+              aria-label={`${photo.caption} を拡大表示`}
+            >
+              <img src={photo.thumb} alt={photo.caption} loading="lazy" />
+            </button>
+          </li>
+        ))}
+      </ul>
+      {openIndex !== null && (
+        <Lightbox
+          photos={photos}
+          index={openIndex}
+          onClose={close}
+          onPrev={prev}
+          onNext={next}
+        />
+      )}
+    </div>
+  )
 }
 
 export default Gallery


### PR DESCRIPTION
## Summary
- Replaces the Gallery stub with a responsive thumbnail grid backed by mock photo data (`src/data/photos.ts`).
- Adds a `Lightbox` component that opens on thumbnail click, showing the large image and caption with prev/next/close buttons, ←/→/Esc keyboard support, and background-click dismiss; locks body scroll while open.

## Test plan
- [ ] Click a thumbnail and confirm the lightbox opens with the matching image and caption
- [ ] Verify ←/→ keys and prev/next buttons cycle through photos (wrapping at the ends)
- [ ] Verify Esc, the × button, and backdrop click all close the lightbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)