### PR TITLE
Add responsive layout and mobile hamburger menu (closes #9)

### DIFF
--- a/src/components/About.css
+++ b/src/components/About.css
@@ -1,7 +1,7 @@
 .about {
-  padding: 4rem 1.5rem;
-  background: #f8fafc;
-  color: #0f172a;
+  padding: clamp(2.5rem, 6vw, 4rem) clamp(1rem, 4vw, 1.5rem);
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .about__inner {
@@ -11,23 +11,23 @@
 
 .about__heading {
   margin: 0 0 2rem;
-  font-size: 1.75rem;
+  font-size: clamp(1.4rem, 3vw, 1.75rem);
   letter-spacing: 0.04em;
-  border-bottom: 2px solid #2563eb;
+  border-bottom: 2px solid var(--color-accent);
   padding-bottom: 0.5rem;
   display: inline-block;
 }
 
 .about__body {
   display: flex;
-  gap: 2.5rem;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
   align-items: flex-start;
   flex-wrap: wrap;
 }
 
 .about__avatar {
-  width: 160px;
-  height: 160px;
+  width: clamp(120px, 22vw, 160px);
+  height: clamp(120px, 22vw, 160px);
   border-radius: 50%;
   object-fit: cover;
   box-shadow: 0 10px 25px rgba(15, 23, 42, 0.12);
@@ -36,6 +36,7 @@
 
 .about__text {
   flex: 1 1 320px;
+  min-width: 0;
 }
 
 .about__name {
@@ -47,13 +48,13 @@
 .about__bio {
   margin: 0 0 1.5rem;
   line-height: 1.85;
-  color: #334155;
+  color: var(--color-text-muted);
 }
 
 .about__facts {
   margin: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem 1.5rem;
 }
 
@@ -62,15 +63,28 @@
 }
 
 .about__fact dt {
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #64748b;
+  color: var(--color-text-muted);
   margin-bottom: 0.25rem;
 }
 
 .about__fact dd {
   margin: 0;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-text);
+}
+
+@media (max-width: 640px) {
+  .about__body {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .about__text {
+    text-align: left;
+    width: 100%;
+  }
 }

--- a/src/components/BlogCard.css
+++ b/src/components/BlogCard.css
@@ -1,16 +1,20 @@
 .blog-card {
-  background: #ffffff;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
   overflow: hidden;
+  height: 100%;
   transition:
     transform 0.15s ease,
-    box-shadow 0.15s ease;
+    box-shadow 0.15s ease,
+    border-color 0.15s ease;
 }
 
-.blog-card:hover {
+.blog-card:hover,
+.blog-card:focus-within {
   transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  border-color: rgba(37, 99, 235, 0.4);
 }
 
 .blog-card__link {
@@ -23,7 +27,7 @@
 
 .blog-card__cover {
   aspect-ratio: 16 / 9;
-  background: #f1f1f1;
+  background: var(--color-surface);
   overflow: hidden;
 }
 
@@ -39,15 +43,16 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  flex: 1;
 }
 
 .blog-card__date {
   font-size: 0.8125rem;
-  color: rgba(0, 0, 0, 0.55);
+  color: var(--color-text-muted);
 }
 
 .blog-card__title {
-  font-size: 1.125rem;
+  font-size: clamp(1rem, 2.4vw, 1.125rem);
   margin: 0;
   line-height: 1.4;
 }
@@ -55,8 +60,8 @@
 .blog-card__excerpt {
   margin: 0;
   font-size: 0.9375rem;
-  color: rgba(0, 0, 0, 0.7);
-  line-height: 1.6;
+  color: var(--color-text-muted);
+  line-height: 1.65;
 }
 
 .blog-card__tags {
@@ -70,8 +75,8 @@
 
 .blog-card__tag {
   font-size: 0.75rem;
-  padding: 0.125rem 0.5rem;
+  padding: 0.15rem 0.55rem;
   border-radius: 999px;
-  background: rgba(0, 0, 0, 0.06);
-  color: rgba(0, 0, 0, 0.7);
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-accent);
 }

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -3,7 +3,7 @@
     radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 60%),
     linear-gradient(135deg, #1e3a8a 0%, #2563eb 55%, #0ea5e9 100%);
   color: #fff;
-  padding: 4.5rem 1.5rem;
+  padding: clamp(2.5rem, 6vw, 4.5rem) clamp(1rem, 4vw, 1.5rem);
 }
 
 .hero__inner {
@@ -11,14 +11,13 @@
   margin: 0 auto;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
-  gap: 3rem;
+  gap: clamp(1.5rem, 4vw, 3rem);
   align-items: center;
 }
 
-@media (max-width: 820px) {
+@media (max-width: 768px) {
   .hero__inner {
     grid-template-columns: 1fr;
-    gap: 2rem;
   }
 }
 
@@ -28,7 +27,7 @@
 
 .hero__greeting {
   margin: 0 0 0.75rem;
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   opacity: 0.85;
@@ -36,15 +35,15 @@
 
 .hero__title {
   margin: 0 0 1.25rem;
-  font-size: clamp(1.9rem, 4.5vw, 3rem);
+  font-size: clamp(1.75rem, 5.5vw, 3rem);
   line-height: 1.25;
   font-weight: 700;
 }
 
 .hero__subtitle {
   margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.7;
+  font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+  line-height: 1.75;
   max-width: 36rem;
   opacity: 0.92;
 }

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -5,18 +5,21 @@
 }
 
 .site-header {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  background: var(--header-bg, #ffffff);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg);
+  position: sticky;
+  top: 0;
+  z-index: 50;
 }
 
 .site-header__inner {
   max-width: 1080px;
   margin: 0 auto;
-  padding: 1rem 1.5rem;
+  padding: 0.875rem 1.25rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 .site-logo {
@@ -26,10 +29,67 @@
   color: inherit;
 }
 
+.site-header__toggle {
+  display: none;
+  background: transparent;
+  border: 0;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: inherit;
+  border-radius: 6px;
+}
+
+.site-header__toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.hamburger {
+  display: inline-block;
+  position: relative;
+  width: 24px;
+  height: 18px;
+}
+
+.hamburger span {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: currentColor;
+  border-radius: 2px;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease,
+    top 0.2s ease;
+}
+
+.hamburger span:nth-child(1) {
+  top: 0;
+}
+.hamburger span:nth-child(2) {
+  top: 8px;
+}
+.hamburger span:nth-child(3) {
+  top: 16px;
+}
+
+.hamburger--open span:nth-child(1) {
+  top: 8px;
+  transform: rotate(45deg);
+}
+.hamburger--open span:nth-child(2) {
+  opacity: 0;
+}
+.hamburger--open span:nth-child(3) {
+  top: 8px;
+  transform: rotate(-45deg);
+}
+
 .site-nav {
   list-style: none;
   display: flex;
-  gap: 1.25rem;
+  gap: 1.5rem;
   margin: 0;
   padding: 0;
 }
@@ -39,10 +99,12 @@
   color: inherit;
   padding: 0.25rem 0;
   border-bottom: 2px solid transparent;
+  font-size: 0.95rem;
 }
 
 .site-nav__link--active {
-  border-bottom-color: currentColor;
+  border-bottom-color: var(--color-accent);
+  color: var(--color-accent);
   font-weight: 600;
 }
 
@@ -51,37 +113,73 @@
   max-width: 1080px;
   width: 100%;
   margin: 0 auto;
-  padding: 2rem 1.5rem;
+  padding: 2rem 1.25rem;
   box-sizing: border-box;
 }
 
 .site-footer {
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
-  background: var(--footer-bg, #f6f6f6);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
 }
 
 .site-footer__inner {
   max-width: 1080px;
   margin: 0 auto;
-  padding: 1.5rem;
+  padding: 1.5rem 1.25rem;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
 }
 
 .site-footer p {
   margin: 0;
 }
 
-@media (prefers-color-scheme: dark) {
-  .site-header {
-    background: #1a1a1a;
-    border-bottom-color: rgba(255, 255, 255, 0.1);
+@media (max-width: 768px) {
+  .site-header__toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    order: 2;
   }
-  .site-footer {
-    background: #141414;
-    border-top-color: rgba(255, 255, 255, 0.1);
+
+  .site-nav-wrapper {
+    order: 3;
+    flex-basis: 100%;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.25s ease;
+  }
+
+  .site-nav-wrapper--open {
+    max-height: 320px;
+  }
+
+  .site-nav {
+    flex-direction: column;
+    gap: 0;
+    padding: 0.5rem 0 0.75rem;
+  }
+
+  .site-nav li {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .site-nav__link {
+    display: block;
+    padding: 0.875rem 0.25rem;
+    border-bottom: none;
+  }
+
+  .site-nav__link--active {
+    border-bottom: none;
+  }
+
+  .site-main {
+    padding: 1.5rem 1rem;
   }
 }

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -39,4 +39,21 @@ describe('Layout', () => {
     await user.click(screen.getByRole('link', { name: 'Gallery' }))
     expect(screen.getByRole('heading', { level: 1, name: 'Gallery' })).toBeInTheDocument()
   })
+
+  it('toggles the mobile menu via the hamburger button', async () => {
+    const user = userEvent.setup()
+    renderAt('/')
+    const toggle = screen.getByLabelText('Open menu')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await user.click(toggle)
+    expect(screen.getByLabelText('Close menu')).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('closes the mobile menu after navigation', async () => {
+    const user = userEvent.setup()
+    renderAt('/')
+    await user.click(screen.getByLabelText('Open menu'))
+    await user.click(screen.getByRole('link', { name: 'Blog' }))
+    expect(screen.getByLabelText('Open menu')).toHaveAttribute('aria-expanded', 'false')
+  })
 })

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,5 @@
-import { NavLink, Outlet } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { NavLink, Outlet, useLocation } from 'react-router-dom'
 import './Layout.css'
 
 const navItems = [
@@ -8,6 +9,13 @@ const navItems = [
 ]
 
 function Layout() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const location = useLocation()
+
+  useEffect(() => {
+    setMenuOpen(false)
+  }, [location.pathname])
+
   return (
     <div className="layout">
       <header className="site-header">
@@ -15,7 +23,25 @@ function Layout() {
           <NavLink to="/" className="site-logo" end>
             Demo Homepage
           </NavLink>
-          <nav aria-label="Primary">
+          <button
+            type="button"
+            className="site-header__toggle"
+            aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={menuOpen}
+            aria-controls="primary-nav"
+            onClick={() => setMenuOpen((open) => !open)}
+          >
+            <span className={`hamburger ${menuOpen ? 'hamburger--open' : ''}`} aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </span>
+          </button>
+          <nav
+            id="primary-nav"
+            aria-label="Primary"
+            className={`site-nav-wrapper ${menuOpen ? 'site-nav-wrapper--open' : ''}`}
+          >
             <ul className="site-nav">
               {navItems.map((item) => (
                 <li key={item.to}>

--- a/src/index.css
+++ b/src/index.css
@@ -1,16 +1,59 @@
 :root {
   font-family:
+    'Inter',
     system-ui,
     -apple-system,
     'Segoe UI',
     Roboto,
+    'Hiragino Sans',
+    'Yu Gothic UI',
     sans-serif;
-  line-height: 1.5;
+  line-height: 1.6;
   color-scheme: light dark;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --color-text: #0f172a;
+  --color-text-muted: #475569;
+  --color-bg: #ffffff;
+  --color-surface: #f8fafc;
+  --color-border: rgba(15, 23, 42, 0.1);
+  --color-accent: #2563eb;
+  --color-accent-strong: #1e3a8a;
+
+  --bp-sm: 640px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
+  color: var(--color-text);
+  background: var(--color-bg);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+h1,
+h2,
+h3 {
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-text: #e2e8f0;
+    --color-text-muted: #94a3b8;
+    --color-bg: #0b1220;
+    --color-surface: #111a2e;
+    --color-border: rgba(226, 232, 240, 0.12);
+  }
 }

--- a/src/pages/Blog.css
+++ b/src/pages/Blog.css
@@ -4,11 +4,22 @@
   gap: 1.5rem;
 }
 
+.blog-page h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.25rem);
+}
+
 .blog-grid {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+}
+
+@media (max-width: 480px) {
+  .blog-grid {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- Standardize breakpoints at 640/768/1024px and introduce theme tokens (`--color-*`) with dark-mode overrides in `index.css`.
- Header collapses into an animated hamburger toggle on mobile (`≤768px`) with `aria-expanded`/`aria-controls`, auto-closing on route change; sticky on scroll.
- Hero, About, and Blog grid use fluid `clamp()` spacing/typography and reflow cleanly at 375 / 768 / 1280px (About stacks centered ≤640px, blog grid single-column ≤480px).

## Test plan
- [x] `pnpm test:run` (9/9 passing, including new hamburger toggle + close-on-navigate tests)
- [x] `pnpm build`
- [ ] Manual spot-check `pnpm dev` at 375 / 768 / 1280px in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)